### PR TITLE
Don't hide forall before S

### DIFF
--- a/EGTBS-Try.lagda
+++ b/EGTBS-Try.lagda
@@ -1625,7 +1625,7 @@ data TmR {-<-}{I}{->-}(D : I -> Desc I)(i : I) : (Cix (Kind I)) where
 We can compute co-de-Bruijn terms from de Bruijn terms, generically.
 \begin{code}
 code   : {-<-}forall {I}{D : I -> Desc I}{i}  ->{->-}  Tm D i           -:>  (TmR D i /_)
-codes  : {-<-}forall {I}{D : I -> Desc I}{->-} S   ->  [! S !! Tm D !]  -:>  ([! S !! TmR D !]R /_)
+codes  : forall {-<-}{I}{D : I -> Desc I}{->-} S   ->  [! S !! Tm D !]  -:>  ([! S !! TmR D !]R /_)
 code                    (_#$_ {jz} x ts)  = map/ #    (vaR x ,R codes (SpD jz) ts)
 code {D = D}{i = i}     [ ts ]            = map/ [_]  (codes (D i) ts)
 codes (RecD k)          t                 = scope k \\R code t

--- a/EGTBS.lagda
+++ b/EGTBS.lagda
@@ -1630,7 +1630,7 @@ data TmR {-<-}{I}{->-}(D : I -> Desc I)(i : I) : (Cix (Kind I)) where
 We can compute co-de-Bruijn terms from de Bruijn terms, generically.
 \begin{code}
 code   : {-<-}forall {I}{D : I -> Desc I}{i}  ->{->-}  Tm D i           -:>  (TmR D i /_)
-codes  : {-<-}forall {I}{D : I -> Desc I}{->-} S   ->  [! S !! Tm D !]  -:>  ([! S !! TmR D !]R /_)
+codes  : forall {-<-}{I}{D : I -> Desc I}{->-} S   ->  [! S !! Tm D !]  -:>  ([! S !! TmR D !]R /_)
 code                    (_#$_ {jz} x ts)  = map/ #    (vaR x ,R codes (SpD jz) ts)
 code {D = D}{i = i}     [ ts ]            = map/ [_]  (codes (D i) ts)
 codes (RecD k)          t                 = scope k \\R code t


### PR DESCRIPTION
Not sure if you want pull requests for this repo, but here's a typo fix! It adds the highlighted forall back into the LaTeX output, so that S doesn't look like it's a type. (This confused me for a while until I read the lagda source.)

<img width="491" alt="EGTBS pdf 2022-04-29 21-28-58" src="https://user-images.githubusercontent.com/524783/166064988-f955007d-ff9b-4db2-b249-b728d7d136fb.png">

I wasn't sure if `EGTBS-Try.lagda` is still used for anything, so applied the fix to both `EGTBS.lagda` and `EGTBS-Try.lagda`.

P.S. Really enjoying this paper -- thanks for the excellent & clear exposition!